### PR TITLE
이메일 인증(회원가입) + 댓글 출력값 수정

### DIFF
--- a/src/main/java/com/example/knockknock/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/knockknock/domain/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.example.knockknock.domain.comment.controller;
 
 import com.example.knockknock.domain.comment.dto.request.CommentRegisterRequestDto;
 import com.example.knockknock.domain.comment.dto.request.CommentUpdateRequestDto;
+import com.example.knockknock.domain.comment.dto.response.GetCommentsResponseDto;
 import com.example.knockknock.domain.comment.service.CommentService;
 import com.example.knockknock.domain.member.security.UserDetailsImpl;
 import com.example.knockknock.global.message.ResponseMessage;
@@ -12,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RequestMapping("/post/comment")
@@ -28,6 +31,13 @@ public class CommentController {
     ) {
         commentService.registerComment(postId, request, userDetails);
         return ResponseMessage.SuccessResponse("댓글 작성 완료", "");
+    }
+
+    @GetMapping("/{postId}/all")
+    public ResponseEntity<List<GetCommentsResponseDto>> getComments(
+            @PathVariable Long postId
+    ) {
+        return new ResponseEntity<>(commentService.getComments(postId), HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/example/knockknock/domain/comment/dto/response/GetCommentsResponseDto.java
+++ b/src/main/java/com/example/knockknock/domain/comment/dto/response/GetCommentsResponseDto.java
@@ -25,7 +25,6 @@ public class GetCommentsResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime modifiedAt;
 
-    private List<GetRepliesResponseDto> replies;
 
 
     public static GetCommentsResponseDto from(Comment comment) {
@@ -38,9 +37,6 @@ public class GetCommentsResponseDto {
             nickName = comment.getMember().getNickName();
         }
 
-        List<GetRepliesResponseDto> replies = comment.getReplies().stream()
-                .map(GetRepliesResponseDto::from)
-                .collect(Collectors.toList());
 
         return GetCommentsResponseDto.builder()
                 .commentId(comment.getCommentId())
@@ -51,7 +47,6 @@ public class GetCommentsResponseDto {
                 .reportCount(comment.getReports().size())
                 .createdAt(comment.getCreatedAt())
                 .modifiedAt(comment.getModifiedAt())
-                .replies(replies)
                 .build();
     }
 

--- a/src/main/java/com/example/knockknock/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/knockknock/domain/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package com.example.knockknock.domain.comment.service;
 
 import com.example.knockknock.domain.comment.dto.request.CommentRegisterRequestDto;
 import com.example.knockknock.domain.comment.dto.request.CommentUpdateRequestDto;
+import com.example.knockknock.domain.comment.dto.response.GetCommentsResponseDto;
 import com.example.knockknock.domain.comment.entity.Comment;
 import com.example.knockknock.domain.comment.repository.CommentRepository;
 import com.example.knockknock.domain.member.entity.Member;
@@ -13,6 +14,9 @@ import com.example.knockknock.global.exception.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +46,16 @@ public class CommentService {
 
         // Comment 저장
         commentRepository.save(comment);
+    }
+
+    @Transactional
+    public List<GetCommentsResponseDto> getComments(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GlobalException(GlobalErrorCode.POST_NOT_FOUND));
+        List<Comment> comments = commentRepository.findByPost(post);
+        return comments.stream()
+                .map(GetCommentsResponseDto::from)
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/com/example/knockknock/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/knockknock/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.example.knockknock.domain.member.dto.response.GetMembersResponseDto;
 import com.example.knockknock.domain.member.dto.response.MemberDetailResponseDto;
 import com.example.knockknock.domain.member.security.UserDetailsImpl;
 import com.example.knockknock.domain.member.service.MemberService;
+import com.example.knockknock.global.exception.GlobalErrorCode;
 import com.example.knockknock.global.message.ResponseMessage;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -35,8 +36,8 @@ public class MemberController {
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<Void> signup(
-            @RequestBody MemberSignUpRequestDto request,
+    public ResponseEntity signup(
+            @RequestPart MemberSignUpRequestDto request,
             @RequestPart(required = false) MultipartFile profileImage){
         memberService.signup(request, profileImage);
         return ResponseMessage.SuccessResponse("회원가입 성공", "");
@@ -54,10 +55,18 @@ public class MemberController {
 
     }
 
-    @PostMapping("/authentication")
+    @PostMapping("/emailcode")
     public ResponseEntity authentication(@RequestBody EmailAuthenticationRequestDto request) {
-        memberService.authentication(request);
+        memberService.sendCode(request);
         return ResponseMessage.SuccessResponse("인증메일을 발송하였습니다", "");
+    }
+
+    @GetMapping("/authentication")
+    public ResponseEntity isAuthenticated (@RequestBody String code) {
+        Boolean isAuthenticated = memberService.isValid(code);
+        if (isAuthenticated){
+        return ResponseMessage.SuccessResponse("인증이 완료되었습니다.", "");
+        } else return ResponseMessage.ErrorResponse(GlobalErrorCode.INVALID_CODE);
     }
 
     @GetMapping()
@@ -75,7 +84,7 @@ public class MemberController {
     @PutMapping("/update")
     public ResponseEntity updateUser(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody MemberUpdateRequestDto request,
+            @RequestPart MemberUpdateRequestDto request,
             @RequestPart(required = false) MultipartFile profileImage
     ) {
         memberService.updateMember(userDetails, request, profileImage);

--- a/src/main/java/com/example/knockknock/domain/member/entity/EmailCode.java
+++ b/src/main/java/com/example/knockknock/domain/member/entity/EmailCode.java
@@ -1,0 +1,22 @@
+package com.example.knockknock.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+public class EmailCode {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long codeId;
+
+    private String email;
+
+    private String code;
+}

--- a/src/main/java/com/example/knockknock/domain/member/repository/EmailCodeRepository.java
+++ b/src/main/java/com/example/knockknock/domain/member/repository/EmailCodeRepository.java
@@ -1,0 +1,13 @@
+package com.example.knockknock.domain.member.repository;
+
+import com.example.knockknock.domain.member.entity.EmailCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailCodeRepository extends JpaRepository<EmailCode, Long> {
+    Optional<EmailCode> findByCode(String code);
+}

--- a/src/main/java/com/example/knockknock/domain/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/com/example/knockknock/domain/post/dto/response/PostDetailResponseDto.java
@@ -28,7 +28,6 @@ public class PostDetailResponseDto {
     private int commentCount;
     private int reportCount;
 
-    private List<GetCommentsResponseDto> comments;
 
     private List<String> hashtags;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -52,9 +51,6 @@ public class PostDetailResponseDto {
                 .map(Hashtag::getTagName)
                 .collect(Collectors.toList());
 
-        List<GetCommentsResponseDto> comments = post.getComments().stream()
-                .map(GetCommentsResponseDto::from)
-                .collect(Collectors.toList());
 
         return PostDetailResponseDto.builder()
                 .postId(post.getPostId())
@@ -67,7 +63,6 @@ public class PostDetailResponseDto {
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getComments().size())
                 .reportCount(post.getReports().size())
-                .comments(comments)
                 .hashtags(hashtagNames)
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())

--- a/src/main/java/com/example/knockknock/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/knockknock/global/config/WebSecurityConfig.java
@@ -54,6 +54,7 @@ public class WebSecurityConfig {
         http.sessionManagement((session) -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         );
+        http.headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()));
 
         return http
                 .authorizeHttpRequests(authorize -> authorize


### PR DESCRIPTION
다음 기능이 추가되었습니다.
이메일 인증 - 코드 발송 -> POST: /member/emailcode
발송된 코드로 인증확인 -> GET: /member/authentication

댓글을 불러왔을 때, 작성자의 프로필 사진도 반환됩니다.