### PR TITLE
Fix/images

### DIFF
--- a/src/main/java/com/example/knockknock/domain/comment/dto/response/GetCommentsResponseDto.java
+++ b/src/main/java/com/example/knockknock/domain/comment/dto/response/GetCommentsResponseDto.java
@@ -29,12 +29,15 @@ public class GetCommentsResponseDto {
 
     public static GetCommentsResponseDto from(Comment comment) {
         String nickName;
-
+        String profileImageUrl;
         Integer anonymousNumber = comment.getPost().getAnonymousNumberByMemberId(comment.getMember().getMemberId());
         if (comment.getIsAnonymous()) {
             nickName = "익명" + anonymousNumber;
+            //익명일 때 기본 프로필 사진
+            profileImageUrl = "https://e7.pngegg.com/pngimages/195/830/png-clipart-emoji-silhouette-service-company-person-emoji-cdr-head.png";
         } else {
             nickName = comment.getMember().getNickName();
+            profileImageUrl = comment.getMember().getProfileImageURL();
         }
 
 
@@ -42,7 +45,7 @@ public class GetCommentsResponseDto {
                 .commentId(comment.getCommentId())
                 .postId(comment.getPost().getPostId())
                 .nickName(nickName)
-                .profileImageUrl(comment.getMember().getProfileImageURL())
+                .profileImageUrl(profileImageUrl)
                 .content(comment.getContent())
                 .reportCount(comment.getReports().size())
                 .createdAt(comment.getCreatedAt())

--- a/src/main/java/com/example/knockknock/domain/post/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/com/example/knockknock/domain/post/dto/response/PostDetailResponseDto.java
@@ -37,10 +37,14 @@ public class PostDetailResponseDto {
 
     public static PostDetailResponseDto of(Post post) {
         String nickName;
+        String profileImageUrl;
         if (post.getIsAnonymous()) {
             nickName = "익명";
+            //익명일 때 기본 프로필 사진
+            profileImageUrl = "https://e7.pngegg.com/pngimages/195/830/png-clipart-emoji-silhouette-service-company-person-emoji-cdr-head.png";
         } else {
             nickName = post.getMember().getNickName();
+            profileImageUrl = post.getMember().getProfileImageURL();
         }
 
         List<String> imageUrls = post.getPostImages().stream()
@@ -55,7 +59,7 @@ public class PostDetailResponseDto {
         return PostDetailResponseDto.builder()
                 .postId(post.getPostId())
                 .boardType(post.getBoardType().ordinal())
-                .profileImageUrl(post.getMember().getProfileImageURL())
+                .profileImageUrl(profileImageUrl)
                 .nickName(nickName)
                 .title(post.getTitle())
                 .content(post.getContent())

--- a/src/main/java/com/example/knockknock/global/image/service/S3Service.java
+++ b/src/main/java/com/example/knockknock/global/image/service/S3Service.java
@@ -10,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 
 import java.io.IOException;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +28,7 @@ public class S3Service {
         metadata.setContentLength(file.getSize());
 
         metadata.setContentDisposition("inline");
+        fileName = getUuidFileName(fileName);
 
         PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata);
 
@@ -36,5 +38,10 @@ public class S3Service {
 
         amazonS3Client.putObject(putObjectRequest);
         return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    public String getUuidFileName(String fileName) {
+        String ext = fileName.substring(fileName.indexOf(".") + 1);
+        return UUID.randomUUID().toString() + "." + ext;
     }
 }


### PR DESCRIPTION
익명으로 작성 시 게시글/뎃글에 포함된 작성자 프로필 사진을 기본이미지로 고정되게
S3관련 오류 방지를 위해 이미지 이름에 고유번호를 부여하여 S3서버에 업로드하도록 유도