### PR TITLE
게시글 이미지 수정방식 변경

### DIFF
--- a/src/main/java/com/example/knockknock/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/knockknock/domain/post/controller/PostController.java
@@ -67,11 +67,11 @@ public class PostController {
         } else return ResponseMessage.ErrorResponse(GlobalErrorCode.PERMISSION_DENIED);
     }
 
-    @Operation(summary = "게시글 수정 (토큰X)", description = "게시글 수정 - imagesToDelete에 삭제할 이미지 Url 배열에 담아 입력")
-    @PutMapping("/{postId}")
+    @Operation(summary = "게시글 수정 (토큰X)", description = "게시글 수정 - 이미지는 게시글 생성 때 이미 들어있던 이미지도 다시 담아서 보내야 함")
+    @PutMapping("/{postId}/edit")
     public ResponseEntity updatePost(
             @PathVariable Long postId,
-            @RequestBody PostUpdateRequestDto request,
+            @RequestPart("request") PostUpdateRequestDto request,
             @RequestPart(required = false) List<MultipartFile> images
     ) {
         postService.updatePost(postId, request, images);

--- a/src/main/java/com/example/knockknock/domain/post/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/com/example/knockknock/domain/post/dto/request/PostUpdateRequestDto.java
@@ -7,7 +7,6 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
-@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostUpdateRequestDto {
@@ -15,7 +14,5 @@ public class PostUpdateRequestDto {
     private String title;
 
     private String content;
-
-    private List<String> imagesToDelete;
 
 }

--- a/src/main/java/com/example/knockknock/domain/post/entity/Post.java
+++ b/src/main/java/com/example/knockknock/domain/post/entity/Post.java
@@ -84,8 +84,12 @@ public class Post extends TimeStamped {
 
 
     public void updatePost(PostUpdateRequestDto request) {
-        this.title = request.getTitle();
-        this.content = request.getContent();
+        if (request.getTitle() != null) {
+            this.title = request.getTitle();
+        }
+        if(request.getContent() != null){
+            this.content = request.getContent();
+        }
     }
 
     public void addPostImage(String imageUrl) {
@@ -96,14 +100,10 @@ public class Post extends TimeStamped {
         postImages.add(postImage);
     }
 
-    public void removePostImage(String imageUrl) {
-        for (PostImage postImage : postImages) {
-            if (postImage.getPostImageUrl().equals(imageUrl)) {
-                postImages.remove(postImage);
+    public void removeAllPostImages() {
+        for (PostImage postImage : this.postImages) {
                 postImage.setPost(null);
-                break;
-            }
-        }
+        } postImages.clear();
     }
 
     public void addComment(Comment comment) {

--- a/src/main/java/com/example/knockknock/domain/post/service/PostService.java
+++ b/src/main/java/com/example/knockknock/domain/post/service/PostService.java
@@ -9,6 +9,7 @@ import com.example.knockknock.domain.hashtag.entity.Hashtag;
 import com.example.knockknock.domain.hashtag.repository.HashtagRepository;
 import com.example.knockknock.domain.member.entity.Member;
 import com.example.knockknock.domain.member.repository.MemberRepository;
+import com.example.knockknock.domain.postimage.PostImage;
 import com.example.knockknock.domain.postlike.repository.PostLikeRepository;
 import com.example.knockknock.domain.post.repository.PostRepository;
 import com.example.knockknock.domain.post.entity.Post;
@@ -97,25 +98,22 @@ public class PostService {
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.POST_NOT_FOUND));
 
         post.updatePost(request);
+        //이미지들 모두 지우기
+        post.removeAllPostImages();
 
-        //이미지 추가
-        if (images != null && !images.isEmpty()) {
-            for (MultipartFile image : images) {
-                String imageUrl = null;
-                try {
-                    imageUrl = s3Service.uploadImage(image);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                post.addPostImage(imageUrl);
-            }
+        if (images == null || images.isEmpty()) {
+            return;
         }
-        //이미지 삭제
-        List<String> imagesToDelete = request.getImagesToDelete();
-        if (imagesToDelete != null && !imagesToDelete.isEmpty()) {
-            for (String imageUrl : imagesToDelete) {
-                post.removePostImage(imageUrl);
+
+        //새로 들어온 이미지로 변경 - 이미 있던 이미지와 동일하더라도 uuid값은 다르기 때문에 이것이 가능
+        for (MultipartFile image : images) {
+            String imageUrl = null;
+            try {
+                imageUrl = s3Service.uploadImage(image);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
+            post.addPostImage(imageUrl);
         }
     }
 


### PR DESCRIPTION
기존엔 multipart로 새로 추가할 이미지를 받고 imageToDelete로 제거할 이미지를 받던 방식에서
수정 시, 기존에 있던 이미지를 모두 지우고 multipart로 추가할 이미지들을 다시 추가하는 방식으로 변경